### PR TITLE
Make the plugin runable out of the box and other minor changes

### DIFF
--- a/src/GitExtensions.PluginTemplate/GitExtensions.PluginTemplate.csproj
+++ b/src/GitExtensions.PluginTemplate/GitExtensions.PluginTemplate.csproj
@@ -48,11 +48,11 @@
   <!-- Pack as .nupkg with dependency on GitExtensions.Plugins -->
   <PropertyGroup>
     <NuspecFile>$(MSBuildThisFileDirectory)$(MSBuildProjectName).nuspec</NuspecFile>
-    <Authors>Maraf</Authors>
-    <Company>Neptuo</Company>
-    <Description>An example of GitExtensions plugin distributed as NuGet package.</Description>
+    <Authors>YOUR NAME HERE</Authors>
+    <Company>YOUR ORGANIZATION HERE</Company>
+    <Description>A template for Git Extensions plugins distributed as NuGet packages.</Description>
     <PackageProjectUrl>https://github.com/gitextensions/gitextensions.plugintemplate</PackageProjectUrl>
-    <PackageTags>Neptuo GitExtensions</PackageTags>
+    <PackageTags>GitExtensions</PackageTags>
   </PropertyGroup>
   <Target Name="SetPackageProperties" BeforeTargets="GenerateNuspec">
     <PropertyGroup>

--- a/src/GitExtensions.PluginTemplate/Plugin.cs
+++ b/src/GitExtensions.PluginTemplate/Plugin.cs
@@ -14,13 +14,20 @@ namespace GitExtensions.PluginTemplate
     {
         public Plugin()
         {
+            /// <summary>
+            /// See: https://github.com/gitextensions/gitextensions.plugintemplate/wiki/GitPluginBase#protected-void-setnameanddescriptionstring-name
+            /// </summary>
             SetNameAndDescription("Plugin Template");
+
+            /// <summary>
+            /// See: https://github.com/gitextensions/gitextensions.plugintemplate/wiki/GitPluginBase#public-image-icon--get-protected-set-
+            /// </summary>
             Icon = Resources.Icon;
         }
 
-        
+
         /// <summary>
-        /// This method is called when the plugin is loaded (either when Git Extensions is opened or when repositories are switched).
+        /// See: https://github.com/gitextensions/gitextensions.plugintemplate/wiki/GitPluginBase#public-virtual-void-registerigituicommands-gituicommands
         /// </summary>
         public override void Register(IGitUICommands gitUiCommands)
         {
@@ -29,7 +36,7 @@ namespace GitExtensions.PluginTemplate
 
 
         /// <summary>
-        /// This method is called when the plugin is unloaded (either when Git Extensions is closed or when repositories are switched).
+        /// See: https://github.com/gitextensions/gitextensions.plugintemplate/wiki/GitPluginBase#public-virtual-void-unregisterigituicommands-gituicommands
         /// </summary>
         public override void Unregister(IGitUICommands gitUiCommands)
         {
@@ -38,7 +45,7 @@ namespace GitExtensions.PluginTemplate
 
 
         /// <summary>
-        /// This method is called from the Git Extensions "Plugins" menu.
+        /// See: https://github.com/gitextensions/gitextensions.plugintemplate/wiki/GitPluginBase#public-abstract-bool-executegituieventargs-args
         /// </summary>
         public override bool Execute(GitUIEventArgs gitUIEventArgs)
         {

--- a/src/GitExtensions.PluginTemplate/Plugin.cs
+++ b/src/GitExtensions.PluginTemplate/Plugin.cs
@@ -1,34 +1,48 @@
 ﻿using GitExtensions.PluginTemplate.Properties;
 using GitUIPluginInterfaces;
 using ResourceManager;
-using System;
-using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace GitExtensions.PluginTemplate
 {
     /// <summary>
-    /// An empty Git Extensions plugin implementation.
+    /// A template for Git Extensions plugins.
     /// </summary>
     [Export(typeof(IGitPlugin))]
     public class Plugin : GitPluginBase
     {
         public Plugin()
         {
-            Name = "PluginTemplate";
-            Description = "Plugin Template";
+            SetNameAndDescription("Plugin Template");
             Icon = Resources.Icon;
         }
 
-        public override bool Execute(GitUIEventArgs e)
+        
+        /// <summary>
+        /// This method is called when the plugin is loaded (either when Git Extensions is opened or when repositories are switched).
+        /// </summary>
+        public override void Register(IGitUICommands gitUiCommands)
         {
-            MessageBox.Show(e.OwnerForm, "Hello from the Plugin Template.", "Git Extensions");
+            
+        }
+
+
+        /// <summary>
+        /// This method is called when the plugin is unloaded (either when Git Extensions is closed or when repositories are switched).
+        /// </summary>
+        public override void Unregister(IGitUICommands gitUiCommands)
+        {
+            
+        }
+
+
+        /// <summary>
+        /// This method is called from the Git Extensions "Plugins" menu.
+        /// </summary>
+        public override bool Execute(GitUIEventArgs gitUIEventArgs)
+        {
+            MessageBox.Show(gitUIEventArgs.OwnerForm, "Hello from the Plugin Template.", "Git Extensions");
             return true;
         }
     }

--- a/src/GitExtensions.PluginTemplate/Properties/launchSettings.json
+++ b/src/GitExtensions.PluginTemplate/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "GitExtensions.PluginTemplate": {
+      "commandName": "Executable",
+      "executablePath": "$(SolutionDir)\\references\\GitExtensions\\GitExtensions.exe"
+    }
+  }
+}


### PR DESCRIPTION
## Proposed changes

- Add `launchSettings.json`, needed to make the plugin runable without further tweaks when pressing F5 in Visual Studio
- Remove not needed using directives in `Plugin.cs`
- Add methods `Register(IGitUICommands gitUiCommands)` and `Unregister(IGitUICommands gitUiCommands)` in `Plugin.cs`, since they are part of the plugin interface
- Minor changes to the nuspec properties